### PR TITLE
Ignore binary data decode and preview & Support copy commit id.

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -425,6 +425,10 @@ class AppBuffer(BrowserBuffer):
         else:
             message_to_emacs("No file need submitted, nothing to copy.")
 
+    @QtCore.pyqtSlot(str)
+    def send_message_to_emacs(self, message):
+        message_to_emacs(message)
+
     def handle_input_response(self, callback_tag, result_content):
         if callback_tag == "copy_changes_file_to_mirror":
             self.handle_copy_changes_file_to_mirror(result_content)

--- a/eaf-git.el
+++ b/eaf-git.el
@@ -133,6 +133,7 @@
       ("u"      ("js_log_unmark_file" "Unmark"))
       ("U"      ("js_log_unmark_all" "Unmark all"))
       ("c"      ("js_log_cherry_pick" "Copyto branch"))
+      ("C"      ("js_log_copy_commit_id" "Copy commit id"))
       ("b"      ("py_log_rebase_branch" "Rebase and merge"))
       ("R"      ("js_log_revert_commit" "Revert"))
       ("z"      ("js_log_reset_last" "Reset last"))

--- a/src/components/Log.vue
+++ b/src/components/Log.vue
@@ -124,6 +124,10 @@
        that.logCherryPick();
      });
 
+     this.$root.$on("log_copy_commit_id", function () {
+       that.logCopyCommitID();
+     });
+
      this.$root.$on("log_select_pg_up", function () {
        that.logSelectPgUp();
      });
@@ -174,6 +178,16 @@
 
        this.pyobject.log_cherry_pick(pickList);
      },
+
+     logCopyCommitID() {
+       const that = this;
+       const commitId = this.logInfo[this.currentLogIndex].id;
+       navigator.clipboard.writeText(commitId).then(() => {
+         that.pyobject.send_message_to_emacs(`Copied ${commitId} successfully.`);
+       }, () => {
+         that.pyobject.send_message_to_emacs(`Copy ${commitId} failed.`);
+       });
+     }
    }
  }
 </script>


### PR DESCRIPTION

1. Detect and ignore large binary file can speed up dashboard's untrack and unstage files preview loading time.
2. Support copy commit id by one key (similar to Github commit list copy button)