### PR TITLE
Refactor merge branch function.

### DIFF
--- a/eaf-git.el
+++ b/eaf-git.el
@@ -147,7 +147,7 @@
       ("c"      ("js_log_cherry_pick" "Copyto branch"))
       ("x"      ("js_log_copy_commit_url" "Copy commit url"))
       ("X"      ("js_log_copy_commit_id" "Copy commit id"))
-      ("b"      ("py_log_rebase_branch" "Rebase and merge from other branch"))
+      ("b"      ("py_log_merge_branch" "Merge from other branch"))
       ("r"      ("js_log_revert_commit" "Revert current"))
       ("R"      ("js_log_revert_to" "Revert all commits above"))
       ("z"      ("js_log_reset_last" "Reset last"))


### PR DESCRIPTION

Refactored the function of merge branch to support three merging methods.

1. Normal merge: This is the most basic merge, which will copy the commit history of the branch. If the master has a new commit since then, an additional commit message will be automatically created during the merge to record the merge operation. 
2. Rebase merge: Between normal and squash, keep the master branch as clean as possible and easy to identify the author of new commits.
3. Squash merge: When merging different branches, you want to have only one commit record after the merge.